### PR TITLE
fix: use user-selected voice for OpenAI requests

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -184,7 +184,7 @@ function openai_tts(text, chosen_provider_options, api_key) {
         body: JSON.stringify({
             "model": "tts-1",
             "input": text,
-            "voice": "alloy"
+            voice
         }),
     })
     .then((res) => {


### PR DESCRIPTION
Bug: The extension supports selecting a voice for OpenAI API requests, but the "alloy" voice was used regardless of the user's preference.

Fix: Pass the user's chosen `voice` to the request body.